### PR TITLE
Fix/migration paths

### DIFF
--- a/dj_bioinformatics_protein/migrations/0001_initial_squashed_0005_auto_20170627_2014.py
+++ b/dj_bioinformatics_protein/migrations/0001_initial_squashed_0005_auto_20170627_2014.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    replaces = [('dj_bioinformatics_protein', '0001_initial'), ('dj_bioinformatics_protein', '0002_remove_alignment_sha256'), ('dj_bioinformatics_protein', '0003_auto_20160227_0008'), ('dj_bioinformatics_protein', '0004_auto_20170621_1918'), ('dj_bioinformatics_protein', '0005_auto_20170627_2014'), ('dj_bioinformatics_protein', '0006_auto_20170707_0908')]
+    replaces = [('dj_bioinformatics_protein', '0001_initial'), ('dj_bioinformatics_protein', '0002_remove_alignment_sha256'), ('dj_bioinformatics_protein', '0003_auto_20160227_0008'), ('dj_bioinformatics_protein', '0004_auto_20170621_1918'), ('dj_bioinformatics_protein', '0005_auto_20170627_2014')]
 
     dependencies = [
     ]

--- a/dj_bioinformatics_protein/migrations/0002_auto_20170707_0908.py
+++ b/dj_bioinformatics_protein/migrations/0002_auto_20170707_0908.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dj_bioinformatics_protein', '0001_initial_squashed_0006_auto_20170707_0908'),
+        ('dj_bioinformatics_protein', '0006_auto_20170707_0908'),
     ]
 
     operations = [

--- a/dj_bioinformatics_protein/migrations/0006_auto_20170707_0908.py
+++ b/dj_bioinformatics_protein/migrations/0006_auto_20170707_0908.py
@@ -9,7 +9,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dj_bioinformatics_protein', '0005_auto_20170627_2014'),
+        ('dj_bioinformatics_protein', '0001_initial_squashed_0005_auto_20170627_2014'),
     ]
 
     operations = [

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dj_bioinformatics_protein',
-      version='1.1.6.1',
+      version='1.1.8',
       description='Django utilities and tools for protein storage and manipulation',
       url='http://github.com/CyrusBiotechnology/dj-protein',
       author='Peter Novotnak, Yifan Song',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dj_bioinformatics_protein',
-      version='1.1.6',
+      version='1.1.6.1',
       description='Django utilities and tools for protein storage and manipulation',
       url='http://github.com/CyrusBiotechnology/dj-protein',
       author='Peter Novotnak, Yifan Song',


### PR DESCRIPTION
Blast-rc is at 0001_initial_squashed_0005_auto_20170627_2014, so this should be an upgrade path that allows it to catch up to 0002_auto