### PR TITLE
Depend on non-squashed migration and pray Django figures it out

### DIFF
--- a/dj_bioinformatics_protein/migrations/0002_auto_20170707_0908.py
+++ b/dj_bioinformatics_protein/migrations/0002_auto_20170707_0908.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dj_bioinformatics_protein', '0001_initial_squashed_0006_auto_20170707_0908'),
+        ('dj_bioinformatics_protein', '0006_auto_20170707_0908'),
     ]
 
     operations = [

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dj_bioinformatics_protein',
-      version='1.1.7',
+      version='1.1.8',
       description='Django utilities and tools for protein storage and manipulation',
       url='http://github.com/CyrusBiotechnology/dj-protein',
       author='Peter Novotnak, Yifan Song',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23556

Django checks for the unsquashed migration as a dependency, and not the squashed name.